### PR TITLE
Add Keep the Why to Tools and In-depth sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ In-depth:
 
 - [Solution Architecture Decisions - By Gareth Morgan](https://www.linkedin.com/pulse/solution-architecture-decisions-gareth-morgan-0r5xe/)
 
+- ["Keep the Why: Code Becomes Legacy When Nobody Remembers Why"](https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why)
+
 Tools:
 
 - [Command-line tools for working with Architecture Decision Records](https://github.com/npryce/adr-tools)

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ Tools:
 
 - [Mneme HQ - ADR enforcement for AI coding agents](https://github.com/TheoV823/mneme)
 
+- [Keep the Why - a repo-native agent skill that continuously captures, or retrospectively recovers, the reasoning behind a codebase](https://github.com/oliver-zehentleitner/keep-the-why)
+
 Company-Specific Guidance:
 
 - [Amazon: AWS Prescriptive Guidance: ADR Process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)


### PR DESCRIPTION
Adds Keep the Why to the **Tools** and **In-depth** subsections of "For more information".

Keep the Why is an open-source agent skill (SKILL.md, cross-agent format) that continuously captures — or retrospectively recovers — the reasoning behind a codebase: architectural decisions, rejected alternatives, workarounds, and incident learnings that the code alone can't explain.

Also links the accompanying article, which covers the underlying problem (decision rationale decay) and how this differs from existing ADR tooling.
  
Both entries formatted to match the existing list style in each section.

Repo: https://github.com/oliver-zehentleitner/keep-the-why
Article: https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why
