### PR TITLE
Add kgai to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,8 @@ Tools:
 
 - [ADR Guard - GitHub Action that fails a pull request changing watched code without an architecture decision record](https://github.com/chohan-sarmad-ali/delivery-gates)
 
+- [kgai - append-only decision log for AI coding agents, a machine-readable companion to ADR files](https://github.com/kgaidev/kgai)
+
 Company-Specific Guidance:
 
 - [Amazon: AWS Prescriptive Guidance: ADR Process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)


### PR DESCRIPTION
Adds one bullet to the Tools list.

kgai is an MIT-licensed CLI and Claude Code plugin that records engineering decisions as the agent works, so an AI assistant can answer "why is this like this" from the team's own history instead of guessing. It runs local-first with no daemon, and team sync is opt-in over an S3 bucket you own.

One design note so the fit is clear up front: kgai's log is append-only. Entries are never edited, and a change of mind is recorded as a new decision that supersedes the earlier one, so the older reasoning stays readable. I know the teamwork section here prefers living, updatable ADRs. This is not meant to argue with that. ADRs stay the human-readable record your team edits. kgai is the machine-readable layer underneath, aimed at what an agent needs at the moment it edits code. Teams that keep ADRs keep them.

Disclosure: we build kgai, so this is a self-submission. Happy to shorten the line, move it to a different section, or close this if it is not a fit.