### PR TITLE
Update Keep the Why Tools entry to match its own description

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Tools:
 
 - [Mneme HQ - ADR enforcement for AI coding agents](https://github.com/TheoV823/mneme)
 
-- [Keep the Why - a repo-native agent skill that continuously captures, or retrospectively recovers, the reasoning behind a codebase](https://github.com/oliver-zehentleitner/keep-the-why)
+- [Keep the Why - a repo-native convention and agent skill that continuously captures, or retrospectively recovers, the reasoning behind a codebase](https://github.com/oliver-zehentleitner/keep-the-why)
 
 Company-Specific Guidance:
 


### PR DESCRIPTION
Keep the Why describes itself as "a repo-native convention and agent skill" (see its own README), but the Tools-list entry here only says "agent skill". Small wording fix to match.