### PR TITLE
Add quern to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ Tools:
 
 - [kgai - append-only decision log for AI coding agents, a machine-readable companion to ADR files](https://github.com/kgaidev/kgai)
 
+- [quern - a decision ledger whose decisions, debts and hypotheses carry rules that go red when the stated rationale stops holding; `quern brief` gives an AI agent the entries that still bind, Apache-2.0](https://github.com/xag/quern)
+
 Company-Specific Guidance:
 
 - [Amazon: AWS Prescriptive Guidance: ADR Process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)


### PR DESCRIPTION
One bullet under `Tools:` in "For more information", following the pattern of the kgai and Keep the Why entries; `README.md` only, per the maintainer skill.

[quern](https://github.com/xag/quern) is a decision ledger for projects built with AI agents: each decision, debt or hypothesis is a node that carries the alternatives rejected and a rule stating when its rationale no longer holds, so the ledger can be checked (`python -m ledger.check`) rather than only read; `quern brief` prints the entries that still bind, one line each, which is what an agent reads at the start of a session instead of the whole history. Python, Apache-2.0, on PyPI.
